### PR TITLE
Fix: Address icon visibility and update location to Laguna Niguel

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Emergence Advisors - Expert Financial & Business Management Consulting | Laguna Beach, CA</title>
-    <meta name="description" content="Emergence Advisors provides expert financial management consulting and business management consulting services in Laguna Beach, CA. Decades of experience bringing time-tested solutions that matter. Not investment advice.">
-    <meta name="keywords" content="financial management consulting, business management consulting, Laguna Beach, Laguna Niguel, business consulting, financial consulting, strategic planning, operational efficiency">
+    <title>Emergence Advisors - Expert Financial & Business Management Consulting | Laguna Niguel, CA</title>
+    <meta name="description" content="Emergence Advisors provides expert financial management consulting and business management consulting services in Laguna Niguel, CA. Decades of experience bringing time-tested solutions that matter. Not investment advice.">
+    <meta name="keywords" content="financial management consulting, business management consulting, Laguna Niguel, business consulting, financial consulting, strategic planning, operational efficiency">
     <meta name="author" content="Emergence Advisors">
     <meta name="robots" content="index, follow">
     
     <!-- Open Graph Tags -->
     <meta property="og:title" content="Emergence Advisors - Expert Financial & Business Management Consulting">
-    <meta property="og:description" content="Expert financial and business management consulting services in Laguna Beach, CA. Decades of combined experience bringing time-tested solutions.">
+    <meta property="og:description" content="Expert financial and business management consulting services in Laguna Niguel, CA. Decades of combined experience bringing time-tested solutions.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://emergenceadvisors.com">
     <meta property="og:image" content="https://cdn1.genspark.ai/user-upload-image/crawler_linkedin_profile_thumbnails/1043a4ca-9c2f-3dab-bd70-b98c9454ef06">
@@ -19,7 +19,7 @@
     <!-- Twitter Card Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Emergence Advisors - Expert Financial & Business Management Consulting">
-    <meta name="twitter:description" content="Expert financial and business management consulting services in Laguna Beach, CA.">
+    <meta name="twitter:description" content="Expert financial and business management consulting services in Laguna Niguel, CA.">
     <meta name="twitter:image" content="https://cdn1.genspark.ai/user-upload-image/crawler_linkedin_profile_thumbnails/1043a4ca-9c2f-3dab-bd70-b98c9454ef06">
     
     <!-- Favicon -->
@@ -27,7 +27,7 @@
     
     <!-- External CSS -->
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
     
     <!-- Schema Markup -->
@@ -42,7 +42,7 @@
         "address": {
             "@type": "PostalAddress",
             "streetAddress": "",
-            "addressLocality": "Laguna Beach",
+            "addressLocality": "Laguna Niguel",
             "addressRegion": "CA",
             "postalCode": "92677",
             "addressCountry": "US"
@@ -201,7 +201,7 @@
                                 Expert Financial & Business Management Consulting
                             </h1>
                             <p class="text-xl mb-8 text-blue-100">
-                                Unlock your business potential with time-tested solutions that matter. Decades of combined experience bringing strategic guidance to businesses in Laguna Beach and beyond.
+                                Unlock your business potential with time-tested solutions that matter. Decades of combined experience bringing strategic guidance to businesses in Laguna Niguel and beyond.
                             </p>
                             <div class="flex flex-col sm:flex-row gap-4">
                                 <button class="bg-white text-blue-600 px-8 py-3 rounded-full font-semibold hover:bg-blue-50 transition-all duration-300 transform hover:scale-105" onclick="showSection('contact')">
@@ -230,7 +230,7 @@
                                     </div>
                                     <div class="flex items-center space-x-3">
                                         <i class="fas fa-check-circle text-yellow-300"></i>
-                                        <span>Local Laguna Beach Expertise</span>
+                                        <span>Local Laguna Niguel Expertise</span>
                                     </div>
                                 </div>
                             </div>
@@ -368,12 +368,12 @@
                     </div>
 
                     <div class="bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-2xl p-12 text-center">
-                        <h2 class="text-3xl font-bold mb-4">Located in Beautiful Laguna Beach, California</h2>
+                        <h2 class="text-3xl font-bold mb-4">Located in Beautiful Laguna Niguel, California</h2>
                         <p class="text-xl mb-8">Serving businesses throughout Orange County and beyond with expert financial and business management consulting services.</p>
                         <div class="flex flex-col sm:flex-row gap-4 justify-center">
                             <div class="flex items-center space-x-2">
                                 <i class="fas fa-map-marker-alt"></i>
-                                <span>Laguna Beach, CA 92677</span>
+                                <span>Laguna Niguel, CA 92677</span>
                             </div>
                             <div class="flex items-center space-x-2">
                                 <i class="fas fa-clock"></i>
@@ -671,7 +671,7 @@
                                 </div>
                                 <div class="text-center">
                                     <div class="bg-green-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                                        <i class="fas fa-target text-2xl text-green-600"></i>
+                                        <i class="fas fa-target text-2xl text-green-600" style="color: #059669 !important; opacity: 1 !important; display: inline-block !important;"></i>
                                     </div>
                                     <h3 class="text-xl font-bold mb-2">Results-Focused</h3>
                                     <p class="text-gray-600">Our process is designed to deliver measurable results and tangible improvements to your business.</p>
@@ -997,7 +997,7 @@
                                     </div>
                                     <div>
                                         <h3 class="font-semibold mb-1">Location</h3>
-                                        <p class="text-gray-600">Laguna Beach, California 92677</p>
+                                        <p class="text-gray-600">Laguna Niguel, California 92677</p>
                                         <p class="text-sm text-gray-500">Serving Orange County and beyond</p>
                                     </div>
                                 </div>
@@ -1125,7 +1125,7 @@
                                             </label>
                                             <label class="flex items-center">
                                                 <input type="radio" name="meeting_format" value="in-person" class="text-blue-600 focus:ring-blue-500">
-                                                <span class="ml-2">In-Person (Laguna Beach area)</span>
+                                                <span class="ml-2">In-Person (Laguna Niguel area)</span>
                                             </label>
                                         </div>
                                     </div>
@@ -1164,7 +1164,7 @@
                     </div>
                     <p class="text-gray-400 mb-4">Expert financial management consulting and business management consulting services. Decades of combined experience bringing time-tested solutions that matter.</p>
                     <div class="text-sm text-gray-500">
-                        <p class="mb-1">📍 Laguna Beach, CA 92677</p>
+                        <p class="mb-1">📍 Laguna Niguel, CA 92677</p>
                         <p class="mb-1">📞 Available upon request</p>
                         <p>📧 info@emergenceadvisors.com</p>
                     </div>


### PR DESCRIPTION
- Applied inline CSS to the 'Results-Focused' (fa-target) icon in the Process section to ensure its visibility, overriding potential conflicting styles.
- Updated all textual references of 'Laguna Beach' to 'Laguna Niguel' across the site, including meta tags, schema markup, contact information, and other descriptive texts.